### PR TITLE
feat(prompt): support custom generated tool hints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type {
 export { createBashTool } from "./tool.js";
 export { DEFAULT_MAX_OUTPUT_LENGTH } from "./tools/bash.js";
 export type {
+  AdditionalToolPromptInfo,
   BashToolCategory,
   BashToolInfo,
   FileFormat,

--- a/src/tool.test.ts
+++ b/src/tool.test.ts
@@ -571,6 +571,41 @@ Common operations:
   cat <file>          # View file contents`);
   });
 
+  it("adds custom prompt tools without replacing generated hints", async () => {
+    const { tools } = await createBashTool({
+      files: { "data.json": "{}" },
+      promptOptions: {
+        additionalTools: [
+          {
+            name: "json-query",
+            purpose: "Query JSON with a custom command",
+            category: "structured-data",
+            formats: ["json"],
+          },
+        ],
+      },
+    });
+
+    expect(
+      tools.bash.description,
+    ).toBe(`Execute bash commands in the sandbox environment.
+
+WORKING DIRECTORY: /workspace
+All commands execute from this directory. Use relative paths from here.
+
+Available files:
+  data.json
+
+Available tools: awk, cat, cut, grep, head, jq, json-query, sed, sort, tail, yq, and more
+For JSON: json-query, jq, grep
+
+Common operations:
+  ls -la              # List files with details
+  find . -name '*.ts' # Find files by pattern
+  grep -r 'pattern' . # Search file contents
+  cat <file>          # View file contents`);
+  });
+
   it("uses empty string toolPrompt to disable tool hints", async () => {
     const { tools } = await createBashTool({
       files: { "data.json": "{}" },

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -184,6 +184,7 @@ export async function createBashTool(
       filenames: fileList,
       isJustBash: usingJustBash,
       toolPrompt: options.promptOptions?.toolPrompt,
+      additionalTools: options.promptOptions?.additionalTools,
     }),
     fileWrittenPromise,
   ]);

--- a/src/tools-prompt.test.ts
+++ b/src/tools-prompt.test.ts
@@ -332,6 +332,26 @@ For YAML: yq, grep, sed`);
 For JSON: grep, sed, cat`);
   });
 
+  it("includes additional tools in generated and format-specific hints", async () => {
+    const sandbox = createMockSandbox(["cat", "grep", "sed"]);
+
+    const prompt = await createToolPrompt({
+      sandbox,
+      filenames: ["data.json"],
+      additionalTools: [
+        {
+          name: "json-query",
+          purpose: "Query JSON with a custom command",
+          category: "structured-data",
+          formats: ["json"],
+        },
+      ],
+    });
+
+    expect(prompt).toBe(`Available tools: cat, grep, json-query, sed, and more
+For JSON: json-query, grep, sed`);
+  });
+
   it("returns custom toolPrompt when provided", async () => {
     const sandbox = createMockSandbox(["cat", "grep", "sed"]);
 
@@ -339,6 +359,14 @@ For JSON: grep, sed, cat`);
       sandbox,
       filenames: ["data.json"],
       toolPrompt: "Custom tool prompt",
+      additionalTools: [
+        {
+          name: "json-query",
+          purpose: "Query JSON with a custom command",
+          category: "structured-data",
+          formats: ["json"],
+        },
+      ],
     });
 
     expect(prompt).toBe("Custom tool prompt");

--- a/src/tools-prompt.ts
+++ b/src/tools-prompt.ts
@@ -10,6 +10,11 @@ export interface BashToolInfo {
   category: BashToolCategory;
 }
 
+export interface AdditionalToolPromptInfo extends BashToolInfo {
+  /** File formats where this tool should be suggested as a primary option. */
+  formats?: FileFormat[];
+}
+
 export type BashToolCategory =
   | "search"
   | "transform"
@@ -321,6 +326,8 @@ export interface ToolPromptOptions {
   isJustBash?: boolean;
   /** Custom tool prompt. If provided, skips tool discovery and returns this value. */
   toolPrompt?: string;
+  /** Extra commands to include in generated tool and format hints. */
+  additionalTools?: AdditionalToolPromptInfo[];
 }
 
 /**
@@ -341,7 +348,13 @@ export interface ToolPromptOptions {
 export async function createToolPrompt(
   options: ToolPromptOptions,
 ): Promise<string> {
-  const { sandbox, filenames, isJustBash = false, toolPrompt } = options;
+  const {
+    sandbox,
+    filenames,
+    isJustBash = false,
+    toolPrompt,
+    additionalTools = [],
+  } = options;
 
   // Return custom toolPrompt if provided
   if (toolPrompt !== undefined) {
@@ -350,6 +363,9 @@ export async function createToolPrompt(
 
   // Discover available tools
   const availableTools = await discoverAvailableTools(sandbox);
+  for (const tool of additionalTools) {
+    availableTools.add(tool.name);
+  }
 
   if (availableTools.size === 0) {
     return "";
@@ -390,6 +406,13 @@ export async function createToolPrompt(
     if (format === "csv" && isJustBash) {
       formatToolNames = ["yq", ...formatToolNames];
     }
+
+    const additionalFormatTools = additionalTools
+      .filter((tool) => tool.formats?.includes(format))
+      .map((tool) => tool.name);
+    formatToolNames = [
+      ...new Set([...additionalFormatTools, ...formatToolNames]),
+    ];
 
     const formatTools = formatToolNames.filter((t) => availableTools.has(t));
     if (formatTools.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { Sandbox as VercelSandbox } from "@vercel/sandbox";
 import type { JustBashLike } from "./sandbox/just-bash.js";
+import type { AdditionalToolPromptInfo } from "./tools-prompt.js";
 
 export interface CommandResult {
   stdout: string;
@@ -61,6 +62,12 @@ export interface PromptOptions {
    * When provided, skips tool discovery entirely.
    */
   toolPrompt?: string;
+
+  /**
+   * Extra commands to include in the generated tool prompt.
+   * Useful when custom sandbox commands are available but do not appear in bin directories.
+   */
+  additionalTools?: AdditionalToolPromptInfo[];
 }
 
 export interface CreateBashToolOptions {


### PR DESCRIPTION
## Summary
- add `promptOptions.additionalTools` so custom sandbox commands can augment generated bash-tool prompts
- include additional tools in the main available-tools line and optional file-format hints
- keep `promptOptions.toolPrompt` as a full override for callers that want to replace prompt generation

Closes #14.

## Verification
- `corepack pnpm@8.15.9 test:run src/tools-prompt.test.ts src/tool.test.ts`
- `corepack pnpm@8.15.9 run typecheck`
- `corepack pnpm@8.15.9 run lint`
- `corepack pnpm@8.15.9 run build`

Note: this checkout required `corepack pnpm@8.15.9 install --frozen-lockfile` because the lockfile is pnpm v8 format while global pnpm is v10.