### PR TITLE
fix(exports): expose individual tool creators

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createBashExecuteTool,
+  createReadFileTool,
+  createWriteFileTool,
+} from "./index.js";
+
+vi.mock("ai", () => ({
+  tool: vi.fn((config) => ({
+    description: config.description,
+    inputSchema: config.inputSchema,
+    execute: config.execute,
+  })),
+}));
+
+describe("public exports", () => {
+  it("exports individual tool creators", () => {
+    expect(createBashExecuteTool).toBeTypeOf("function");
+    expect(createReadFileTool).toBeTypeOf("function");
+    expect(createWriteFileTool).toBeTypeOf("function");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,15 @@ export type {
   SkillToolkit,
 } from "./skills/types.js";
 export { createBashTool } from "./tool.js";
-export { DEFAULT_MAX_OUTPUT_LENGTH } from "./tools/bash.js";
+export type { CreateBashExecuteToolOptions } from "./tools/bash.js";
+export {
+  createBashExecuteTool,
+  DEFAULT_MAX_OUTPUT_LENGTH,
+} from "./tools/bash.js";
+export type { CreateReadFileToolOptions } from "./tools/read-file.js";
+export { createReadFileTool } from "./tools/read-file.js";
+export type { CreateWriteFileToolOptions } from "./tools/write-file.js";
+export { createWriteFileTool } from "./tools/write-file.js";
 export type {
   BashToolCategory,
   BashToolInfo,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -16,7 +16,7 @@ const bashSchema = z.object({
 /** Default maximum length for stdout/stderr output (30KB) */
 export const DEFAULT_MAX_OUTPUT_LENGTH = 30_000;
 
-interface CreateBashToolOptions {
+export interface CreateBashExecuteToolOptions {
   sandbox: Sandbox;
   /** Working directory for command execution */
   cwd: string;
@@ -61,7 +61,7 @@ function truncateOutput(
   )}\n\n[${streamName} truncated: ${truncatedLength} characters removed]`;
 }
 
-function generateDescription(options: CreateBashToolOptions): string {
+function generateDescription(options: CreateBashExecuteToolOptions): string {
   const {
     cwd,
     files,
@@ -129,7 +129,7 @@ function generateDescription(options: CreateBashToolOptions): string {
   return lines.join("\n").trim();
 }
 
-export function createBashExecuteTool(options: CreateBashToolOptions) {
+export function createBashExecuteTool(options: CreateBashExecuteToolOptions) {
   const {
     sandbox,
     cwd,

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -7,7 +7,7 @@ const readFileSchema = z.object({
   path: z.string().describe("The path to the file to read"),
 });
 
-interface CreateReadFileToolOptions {
+export interface CreateReadFileToolOptions {
   sandbox: Sandbox;
   /** Working directory for resolving relative paths */
   cwd: string;

--- a/src/tools/write-file.ts
+++ b/src/tools/write-file.ts
@@ -8,7 +8,7 @@ const writeFileSchema = z.object({
   content: z.string().describe("The content to write to the file"),
 });
 
-interface CreateWriteFileToolOptions {
+export interface CreateWriteFileToolOptions {
   sandbox: Sandbox;
   /** Working directory for resolving relative paths */
   cwd: string;


### PR DESCRIPTION
## Summary

Fixes #17.

`createBashTool()` is useful when a caller can resolve and prepare a sandbox before constructing tools, but durable/orchestrated runtimes sometimes need to define tool schemas in one context and execute against a sandbox proxy in another context.

The individual tool creator functions already exist internally and only need a `Sandbox` interface plus `cwd`. This PR exposes them from the package root so callers can compose them with custom sandbox implementations:

- `createBashExecuteTool`
- `createReadFileTool`
- `createWriteFileTool`

It also exports the corresponding option types and adds a public export smoke test.

## Verification

- `pnpm run test:run -- src/index.test.ts src/tools/bash.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run lint`
- `git diff --check`
