### PR TITLE
fix: sort glob results for deterministic file order

### DIFF
--- a/src/files/loader.ts
+++ b/src/files/loader.ts
@@ -38,12 +38,14 @@ export async function* streamFiles(
     const { source, include = "**/*" } = options.uploadDirectory;
     const absoluteSource = path.resolve(source);
 
-    const foundPaths = await fg(include, {
-      cwd: absoluteSource,
-      dot: true,
-      onlyFiles: true,
-      ignore: ["**/node_modules/**", "**/.git/**"],
-    });
+    const foundPaths = (
+      await fg(include, {
+        cwd: absoluteSource,
+        dot: true,
+        onlyFiles: true,
+        ignore: ["**/node_modules/**", "**/.git/**"],
+      })
+    ).sort();
 
     for (const relativePath of foundPaths) {
       if (yieldedPaths.has(relativePath)) {
@@ -69,12 +71,14 @@ export async function getFilePaths(
     const { source, include = "**/*" } = options.uploadDirectory;
     const absoluteSource = path.resolve(source);
 
-    const foundPaths = await fg(include, {
-      cwd: absoluteSource,
-      dot: true,
-      onlyFiles: true,
-      ignore: ["**/node_modules/**", "**/.git/**"],
-    });
+    const foundPaths = (
+      await fg(include, {
+        cwd: absoluteSource,
+        dot: true,
+        onlyFiles: true,
+        ignore: ["**/node_modules/**", "**/.git/**"],
+      })
+    ).sort();
     paths.push(...foundPaths);
   }
 


### PR DESCRIPTION
## Problem

`fast-glob` returns files in arbitrary filesystem traversal order, which varies across runs on the same directory. This causes the bash tool's `description` string to differ between calls — the \"Available files\" section lists up to 8 files sampled from the front of the array, so a different ordering produces a different prompt, breaking prompt cache hits.

From the fast-glob README:
> results are returned in **arbitrary order**

## Fix

Sort the `foundPaths` array returned by `fg()` in both `streamFiles` and `getFilePaths` in `src/files/loader.ts`. This gives stable lexicographic order regardless of OS or filesystem traversal behavior.

The change is minimal — a single `.sort()` chained on each `fg()` call — and has no functional impact beyond ordering.

Made with [Cursor](https://cursor.com)