### PR TITLE
support lazy sandbox initialization

### DIFF
--- a/AGENTS.npm.md
+++ b/AGENTS.npm.md
@@ -70,6 +70,27 @@ const { tools } = await createBashTool({ sandbox: vm });
 // Call vm.stop() when done
 ```
 
+### create a sandbox only when a tool runs
+
+```typescript
+import { Sandbox } from "@vercel/sandbox";
+
+const { tools } = await createBashTool({
+  sandbox: () => Sandbox.create(),
+  destination: "/vercel/sandbox/workspace",
+});
+```
+
+the provider runs once, when `bash`, `readFile`, `writeFile`, or a returned
+sandbox method is first used. files are uploaded after the provider resolves
+and before the requested operation runs.
+
+because the sandbox type is unknown until then, lazy providers default to
+`/workspace`. set `destination` for sandboxes with a different working
+directory. automatic tool discovery is also skipped to preserve lazy
+initialization. use `promptOptions.toolPrompt` to add sandbox-specific tool
+hints.
+
 ### Persistent sandbox across serverless invocations
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -107,6 +107,29 @@ const { tools } = await createBashTool({
 });
 ```
 
+### create a sandbox only when a tool runs
+
+pass a provider when most requests do not need shell access:
+
+```typescript
+import { Sandbox } from "@vercel/sandbox";
+
+const { tools } = await createBashTool({
+  sandbox: () => Sandbox.create(),
+  destination: "/vercel/sandbox/workspace",
+});
+```
+
+the provider runs once, when `bash`, `readFile`, `writeFile`, or a returned
+sandbox method is first used. files are uploaded after the provider resolves
+and before the requested operation runs.
+
+lazy providers default to `/workspace` because their sandbox type is unknown
+until first use. set `destination` for sandboxes with a different working
+directory. automatic tool discovery is skipped to preserve lazy
+initialization. use `promptOptions.toolPrompt` to add sandbox-specific tool
+hints.
+
 ### Persistent sandbox across serverless invocations
 
 Use `Sandbox.get` to reconnect to an existing sandbox by ID:

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,5 +30,7 @@ export type {
   CreateBashToolOptions,
   PromptOptions,
   Sandbox,
+  SandboxInstance,
+  SandboxProvider,
   VercelSandboxInstance,
 } from "./types.js";

--- a/src/tool.test.ts
+++ b/src/tool.test.ts
@@ -337,6 +337,113 @@ describe("createBashTool", () => {
     expect(result.stdout).toBe("custom");
   });
 
+  it("creates a provided sandbox only when a tool first uses it", async () => {
+    const calls: string[] = [];
+    const customSandbox = {
+      executeCommand: vi.fn().mockImplementation(async () => {
+        calls.push("execute");
+        return { stdout: "lazy", stderr: "", exitCode: 0 };
+      }),
+      readFile: vi.fn().mockResolvedValue("lazy content"),
+      writeFiles: vi.fn().mockImplementation(async () => {
+        calls.push("write");
+      }),
+    };
+    const sandboxProvider = vi.fn().mockImplementation(async () => {
+      calls.push("create");
+      return customSandbox;
+    });
+
+    const { tools, sandbox } = await createBashTool({
+      sandbox: sandboxProvider,
+      files: { "test.txt": "content" },
+    });
+
+    expect(sandboxProvider).not.toHaveBeenCalled();
+    expect(customSandbox.writeFiles).not.toHaveBeenCalled();
+
+    assert(tools.bash.execute, "bash.execute should be defined");
+    const result = (await tools.bash.execute(
+      { command: "pwd" },
+      opts,
+    )) as CommandResult;
+
+    expect(result.stdout).toBe("lazy");
+    expect(calls).toEqual(["create", "write", "execute"]);
+    expect(customSandbox.writeFiles).toHaveBeenCalledWith([
+      { path: "/workspace/test.txt", content: Buffer.from("content") },
+    ]);
+
+    await sandbox.readFile("/workspace/test.txt");
+    assert(tools.writeFile.execute, "writeFile.execute should be defined");
+    await tools.writeFile.execute(
+      { path: "other.txt", content: "other" },
+      opts,
+    );
+
+    expect(sandboxProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps a lazily created Vercel sandbox", async () => {
+    const vercelSandbox = {
+      sandboxId: "sandbox_123",
+      runCommand: vi.fn().mockResolvedValue({
+        exitCode: 0,
+        stdout: vi.fn().mockResolvedValue("vercel"),
+        stderr: vi.fn().mockResolvedValue(""),
+      }),
+      readFile: vi.fn().mockResolvedValue(null),
+      writeFiles: vi.fn().mockResolvedValue(undefined),
+    };
+    const sandboxProvider = vi.fn().mockResolvedValue(vercelSandbox);
+
+    const { tools } = await createBashTool({
+      sandbox: sandboxProvider,
+      destination: "/vercel/sandbox/workspace",
+      files: { "test.txt": "content" },
+    });
+
+    expect(sandboxProvider).not.toHaveBeenCalled();
+
+    assert(tools.bash.execute, "bash.execute should be defined");
+    const result = (await tools.bash.execute(
+      { command: "pwd" },
+      opts,
+    )) as CommandResult;
+
+    expect(result.stdout).toBe("vercel");
+    expect(vercelSandbox.writeFiles).toHaveBeenCalledWith([
+      {
+        path: "/vercel/sandbox/workspace/test.txt",
+        content: Buffer.from("content"),
+      },
+    ]);
+    expect(vercelSandbox.runCommand).toHaveBeenCalledWith("bash", [
+      "-c",
+      'cd "/vercel/sandbox/workspace" && pwd',
+    ]);
+    expect(sandboxProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates lazy sandbox files before creating the sandbox", async () => {
+    const sandboxProvider = vi.fn();
+
+    await expect(
+      createBashTool({
+        sandbox: sandboxProvider,
+        files: {
+          "one.txt": "one",
+          "two.txt": "two",
+        },
+        maxFiles: 1,
+      }),
+    ).rejects.toThrow(
+      /Too many files to upload: 2 files exceeds the limit of 1/,
+    );
+
+    expect(sandboxProvider).not.toHaveBeenCalled();
+  });
+
   it("writes files in batches of 20 to custom sandbox", async () => {
     const customSandbox = {
       executeCommand: vi

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -10,12 +10,65 @@ import { createBashExecuteTool } from "./tools/bash.js";
 import { createReadFileTool } from "./tools/read-file.js";
 import { createWriteFileTool } from "./tools/write-file.js";
 import { createToolPrompt } from "./tools-prompt.js";
-import type { BashToolkit, CreateBashToolOptions, Sandbox } from "./types.js";
+import type {
+  BashToolkit,
+  CreateBashToolOptions,
+  Sandbox,
+  SandboxInstance,
+  SandboxProvider,
+} from "./types.js";
 
 const DEFAULT_DESTINATION = "/workspace";
 const VERCEL_SANDBOX_DESTINATION = "/vercel/sandbox/workspace";
 const WRITE_BATCH_SIZE = 20;
 const DEFAULT_MAX_FILES = 1000;
+
+function isSandboxProvider(
+  sandbox: CreateBashToolOptions["sandbox"],
+): sandbox is SandboxProvider {
+  return typeof sandbox === "function";
+}
+
+function normalizeSandbox(sandbox: SandboxInstance): {
+  sandbox: Sandbox;
+  usingJustBash: boolean;
+} {
+  if (isVercelSandbox(sandbox)) {
+    return { sandbox: wrapVercelSandbox(sandbox), usingJustBash: false };
+  }
+
+  if (isJustBash(sandbox)) {
+    return { sandbox: wrapJustBash(sandbox), usingJustBash: true };
+  }
+
+  return { sandbox: sandbox as Sandbox, usingJustBash: false };
+}
+
+async function writeFilesToSandbox(options: {
+  sandbox: Sandbox;
+  destination: string;
+  files: CreateBashToolOptions["files"];
+  uploadDirectory: CreateBashToolOptions["uploadDirectory"];
+}): Promise<void> {
+  const { sandbox, destination, files, uploadDirectory } = options;
+  let batch: Array<{ path: string; content: Buffer }> = [];
+
+  for await (const file of streamFiles({ files, uploadDirectory })) {
+    batch.push({
+      path: path.posix.join(destination, file.path),
+      content: file.content,
+    });
+
+    if (batch.length >= WRITE_BATCH_SIZE) {
+      await sandbox.writeFiles(batch);
+      batch = [];
+    }
+  }
+
+  if (batch.length > 0) {
+    await sandbox.writeFiles(batch);
+  }
+}
 
 /**
  * Creates a bash tool with tools for AI agents.
@@ -46,9 +99,13 @@ const DEFAULT_MAX_FILES = 1000;
 export async function createBashTool(
   options: CreateBashToolOptions = {},
 ): Promise<BashToolkit> {
+  const lazySandboxProvider = isSandboxProvider(options.sandbox)
+    ? options.sandbox
+    : undefined;
+
   // Determine default destination based on sandbox type
   const defaultDestination =
-    options.sandbox && isVercelSandbox(options.sandbox)
+    options.sandbox && !lazySandboxProvider && isVercelSandbox(options.sandbox)
       ? VERCEL_SANDBOX_DESTINATION
       : DEFAULT_DESTINATION;
   const destination = options.destination ?? defaultDestination;
@@ -63,17 +120,51 @@ export async function createBashTool(
 
   let fileWrittenPromise: Promise<void> | undefined;
 
-  if (options.sandbox) {
-    // External sandbox provided - stream files and write in batches
-    // Check @vercel/sandbox first (more specific check)
-    if (isVercelSandbox(options.sandbox)) {
-      sandbox = wrapVercelSandbox(options.sandbox);
-    } else if (isJustBash(options.sandbox)) {
-      sandbox = wrapJustBash(options.sandbox);
-      usingJustBash = true;
-    } else {
-      sandbox = options.sandbox as Sandbox;
+  if (lazySandboxProvider) {
+    fileList = await getFilePaths({
+      files: options.files,
+      uploadDirectory: options.uploadDirectory,
+    });
+
+    if (maxFiles > 0 && fileList.length > maxFiles) {
+      throw new Error(
+        `Too many files to upload: ${fileList.length} files exceeds the limit of ${maxFiles}. ` +
+          `Either increase maxFiles, use a more restrictive include pattern in uploadDirectory, ` +
+          `or write files to the sandbox yourself before calling createBashTool.`,
+      );
     }
+
+    let sandboxPromise: Promise<Sandbox> | undefined;
+    const getSandbox = (): Promise<Sandbox> => {
+      sandboxPromise ??= (async () => {
+        const resolved = normalizeSandbox(await lazySandboxProvider());
+        await writeFilesToSandbox({
+          sandbox: resolved.sandbox,
+          destination,
+          files: options.files,
+          uploadDirectory: options.uploadDirectory,
+        });
+        return resolved.sandbox;
+      })();
+      return sandboxPromise;
+    };
+
+    sandbox = {
+      async executeCommand(command) {
+        return (await getSandbox()).executeCommand(command);
+      },
+      async readFile(filePath) {
+        return (await getSandbox()).readFile(filePath);
+      },
+      async writeFiles(files) {
+        return (await getSandbox()).writeFiles(files);
+      },
+    };
+  } else if (options.sandbox && !isSandboxProvider(options.sandbox)) {
+    // External sandbox provided - stream files and write in batches
+    const normalized = normalizeSandbox(options.sandbox);
+    sandbox = normalized.sandbox;
+    usingJustBash = normalized.usingJustBash;
 
     // Get file paths for tool prompt (without loading content)
     fileList = await getFilePaths({
@@ -91,29 +182,12 @@ export async function createBashTool(
     }
 
     // Stream files and write in batches to avoid memory issues
-    fileWrittenPromise = (async () => {
-      let batch: Array<{ path: string; content: Buffer }> = [];
-
-      for await (const file of streamFiles({
-        files: options.files,
-        uploadDirectory: options.uploadDirectory,
-      })) {
-        batch.push({
-          path: path.posix.join(destination, file.path),
-          content: file.content,
-        });
-
-        if (batch.length >= WRITE_BATCH_SIZE) {
-          await sandbox.writeFiles(batch);
-          batch = [];
-        }
-      }
-
-      // Write remaining files
-      if (batch.length > 0) {
-        await sandbox.writeFiles(batch);
-      }
-    })();
+    fileWrittenPromise = writeFilesToSandbox({
+      sandbox,
+      destination,
+      files: options.files,
+      uploadDirectory: options.uploadDirectory,
+    });
   } else {
     // No external sandbox - use just-bash
     usingJustBash = true;
@@ -183,7 +257,9 @@ export async function createBashTool(
       sandbox,
       filenames: fileList,
       isJustBash: usingJustBash,
-      toolPrompt: options.promptOptions?.toolPrompt,
+      toolPrompt: lazySandboxProvider
+        ? (options.promptOptions?.toolPrompt ?? "")
+        : options.promptOptions?.toolPrompt,
     }),
     fileWrittenPromise,
   ]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,16 @@ export interface PromptOptions {
   toolPrompt?: string;
 }
 
+export type SandboxInstance = Sandbox | VercelSandbox | JustBashLike;
+
+/**
+ * creates a sandbox when one of the returned tools first needs it.
+ *
+ * the provider is called at most once and may return any supported sandbox
+ * instance.
+ */
+export type SandboxProvider = () => SandboxInstance | Promise<SandboxInstance>;
+
 export interface CreateBashToolOptions {
   /**
    * Destination directory on the sandbox for files.
@@ -95,9 +105,14 @@ export interface CreateBashToolOptions {
   /**
    * Override the default just-bash sandbox.
    * Accepts a @vercel/sandbox instance, just-bash Bash instance,
-   * or any object implementing Sandbox.
+   * any object implementing Sandbox, or a provider for lazy initialization.
+   *
+   * lazy providers are called at most once, when a returned tool or sandbox
+   * method is first used. automatic tool discovery is skipped until then, so
+   * provide promptOptions.toolPrompt when tool-specific prompt hints are
+   * needed.
    */
-  sandbox?: Sandbox | VercelSandbox | JustBashLike;
+  sandbox?: SandboxInstance | SandboxProvider;
 
   /**
    * Additional instructions to append to tool descriptions.


### PR DESCRIPTION
## summary

this lets `createBashTool` accept a sandbox provider that is resolved only when a returned tool or sandbox method first needs it.

the provider is memoized, initial files are uploaded before the first operation, and existing sandbox instances keep their current behavior. lazy providers can set `promptOptions.toolPrompt` when they need sandbox-specific tool hints without triggering eager discovery.

closes #18

## testing

- `biome check .`
- `knip`
- `tsc --noEmit`
- `tsc --noEmit -p tsconfig.examples.json`
- `tsc -p tsconfig.build.json`
- `vitest run --exclude 'src/tool.vercel.integration.test.ts'` with 155 tests passing

live Vercel integration was not run because it requires sandbox credentials. the lazy Vercel adapter path is covered with a unit test.
